### PR TITLE
Delete appointment bug-fix

### DIFF
--- a/src/test/java/seedu/address/testutil/LogicStub.java
+++ b/src/test/java/seedu/address/testutil/LogicStub.java
@@ -10,6 +10,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -32,6 +33,11 @@ public class LogicStub implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return new FilteredList<Person>(FXCollections.observableArrayList());
+    }
+
+    @Override
+    public ObservableList<Appointment> getFilteredAppointmentList() {
+        return new FilteredList<Appointment>(FXCollections.observableArrayList());
     }
 
     @Override

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -80,7 +81,16 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public ObservableList<Appointment> getFilteredAppointmentList() {
+        throw new AssertionError("This method should not be called.");
+    }
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
         throw new AssertionError("This method should not be called.");
     }
 }


### PR DESCRIPTION
Resolved 
1. `ModelStub` is not abstract and does not override abstract method `updateFilteredAppointmentList(Predicate<Appointment>)` in Model
2. `LogicStub` is not abstract and does not override abstract method `getFilteredAppointmentList()` in Logic