### PR TITLE
Update validation regex for name

### DIFF
--- a/src/main/java/seedu/address/model/student/Name.java
+++ b/src/main/java/seedu/address/model/student/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^(?=.{1,100}$)[A-Z][a-z]*([A-Za-z ]*)*$";
+    public static final String VALIDATION_REGEX = "^(?=.{1,100}$)[A-Z][a-z]*([ ][A-Z][a-z]*)*\\s*$";
 
     public final String value;
 
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return value.toLowerCase().equals(otherName.value.toLowerCase());
+        return value.equals(otherName.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/Name.java
+++ b/src/main/java/seedu/address/model/student/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[A-Za-z][A-Za-z ]{0,99}$";
+    public static final String VALIDATION_REGEX = "^(?=.{1,100}$)[A-Z][a-z]*([A-Za-z ]*)*$";
 
     public final String value;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
@@ -69,7 +69,7 @@ class JsonAdaptedStudent {
     public Student toModelType() throws IllegalValueException {
         final List<RiskLevel> studentRiskLevel = new ArrayList<>();
 
-
+        System.out.println(name);
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }

--- a/src/test/java/seedu/address/model/student/NameTest.java
+++ b/src/test/java/seedu/address/model/student/NameTest.java
@@ -44,7 +44,7 @@ public class NameTest {
 
         // valid names
         // EP: one character alphabet only
-        assertTrue(Name.isValidName("a"));
+        assertTrue(Name.isValidName("A"));
 
         // EP: Alphabetical characters with capital letters
         assertTrue(Name.isValidName("Capital Tan"));

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -40,13 +40,9 @@ public class StudentTest {
         editedAlice = new StudentBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // name differs in case, all other attributes same -> returns true
-        Student editedBob = new StudentBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertTrue(BOB.isSameStudent(editedBob));
-
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new StudentBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        Student editedBob = new StudentBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSameStudent(editedBob));
     }
 


### PR DESCRIPTION
Should only now allow for inputs that start off with a capitalised letter for each word and the rest are lower case.
e.g. John Doe is accepted, but joHn doE, john doe, JOHN DOE are all not allowed